### PR TITLE
Fix Django restart service handler name

### DIFF
--- a/tasks/static.yml
+++ b/tasks/static.yml
@@ -6,4 +6,4 @@
   become: True
   become_user: "{{ tally_ho_django_system_user }}"
   notify:
-    - restart_service
+    - Restart Django Service


### PR DESCRIPTION
### Changes
---
- Update Django restart service handler name that got updated [here](https://github.com/onaio/ansible-django/pull/45/commits/db9b8ee6174f8165474952bc071498620d7bcebe).