### PR TITLE
support for uv mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.retry
 *.log
 .ansible
-.vagrant/
+.vagrant

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.retry
 *.log
+.ansible
 .vagrant/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -151,8 +151,6 @@ tally_ho_django_pip_packages:
 
 tally_ho_django_git_url: "git@github.com:onaio/tally-ho.git"
 tally_ho_django_git_version: "master"
-tally_ho_django_tally_ho_use_regular_old_pip: false
-tally_ho_django_tally_ho_use_pipenv: true
 tally_ho_django_system_wide_dependencies:
   - build-essential
   - git

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -116,8 +116,6 @@ tally_ho_django_versioned_path: "{{ tally_ho_django_codebase_path }}-versioned"
 tally_ho_django_checkout_path: "{{ tally_ho_django_versioned_path }}/{{ ansible_date_time['epoch'] }}"
 tally_ho_django_venv_path: "{{ tally_ho_django_system_user_home }}/.virtualenvs/{{ tally_ho_django_system_user }}"
 tally_ho_django_settings_template: "checkoutpath/tally_ho/config/settings.py.j2"
-tally_ho_requirements_paths:
-  - "{{ tally_ho_django_checkout_path }}/requirements/dev.pip"
 tally_ho_django_python_source_version: "3.12"
 tally_ho_django_python_version: "python3.12"
 tally_ho_django_python_packages:
@@ -180,7 +178,6 @@ tally_ho_django_top_python_statements:
 ## python statements included at the bottom of settings file
 tally_ho_django_bottom_python_statements:
   - CSRF_TRUSTED_ORIGINS = CORS_ORIGIN_WHITELIST
-tally_ho_django_setuptools_version: "57.5.0"
 
 # Certbot
 tally_ho_use_certbot: True

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -67,7 +67,8 @@ dependencies:
       django_wsgi_module: "{{ tally_ho_django_wsgi_module }}"
       django_init_commands: "{{ tally_ho_django_init_commands }}"
       django_pip_packages: "{{ tally_ho_django_pip_packages }}"
-      django_use_regular_old_pip: true
+      django_use_uv: true
+      django_use_regular_old_pip: false
       django_use_pipenv: false
       django_system_wide_dependencies: "{{ tally_ho_django_system_wide_dependencies }}"
       django_manage_services: true
@@ -85,7 +86,6 @@ dependencies:
       django_proxy_read_timeout: "{{ tally_ho_django_proxy_read_timeout }}"
       django_top_python_statements: "{{ tally_ho_django_top_python_statements  }}"
       django_bottom_python_statements: "{{ tally_ho_django_bottom_python_statements  }}"
-      django_pip_paths: "{{ tally_ho_requirements_paths }}"
       django_settings_template_path: "{{ tally_ho_django_settings_template_path }}"
       django_copy_key_from_file: true
       django_celery_app: "{{ tally_ho_django_celery_app }}"
@@ -94,6 +94,5 @@ dependencies:
       django_enable_celery: "{{ tally_ho_django_enable_celery }}"
       django_wsgi_env: "{{ tally_ho_django_wsgi_env }}"
       django_python_packages: "{{ tally_ho_django_python_packages }}"
-      django_setuptools_version: "{{ tally_ho_django_setuptools_version }}"
     tags:
       - django

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -70,6 +70,7 @@ dependencies:
       django_use_uv: true
       django_use_regular_old_pip: false
       django_use_pipenv: false
+      django_use_poetry: false
       django_system_wide_dependencies: "{{ tally_ho_django_system_wide_dependencies }}"
       django_manage_services: true
       django_service_name: "{{ tally_ho_django_service_name }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,8 @@
   version: eca5049500549c4e12cb4cb663a8b4f8499ac39b
 - src: git+https://github.com/onaio/ansible-django
   name: django
-  version: master
+  # TODO: pin to a sha once the uv-support branch lands on main.
+  version: main
 - src: https://github.com/ANXS/postgresql
   name: ANXS.postgresql
   version: f326a92b02e63224a65076565cc9873768faee25

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,8 +4,7 @@
   version: eca5049500549c4e12cb4cb663a8b4f8499ac39b
 - src: git+https://github.com/onaio/ansible-django
   name: django
-  # TODO: pin to a sha once the uv-support branch lands on main.
-  version: main
+  version: 5d4a6b98005f1c99ca3a02b5e7336c55a8276274
 - src: https://github.com/ANXS/postgresql
   name: ANXS.postgresql
   version: f326a92b02e63224a65076565cc9873768faee25


### PR DESCRIPTION
## Summary

Switches the tally-ho deploy from `pip install -r requirements/dev.pip` to `uv sync --frozen --no-dev` by opting into the new `django_use_uv` mode added in onaio/ansible-django#51.

## Why

Required by onaio/tally-ho#561 — that PR migrates tally-ho's dependency management to `pyproject.toml` + `uv.lock` and deletes `requirements/*.pip`. Without this PR (and the upstream onaio/ansible-django#51), the next deploy fails because `requirements/dev.pip` no longer exists in the tally-ho checkout.

## What changed

- `meta/main.yml` — flipped to `django_use_uv: true`; dropped `django_pip_paths` (uv reads pyproject + lockfile directly) and the obsolete `django_setuptools_version` pin.
- `defaults/main.yml` — dropped `tally_ho_requirements_paths` and `tally_ho_django_setuptools_version` (no longer referenced).
- `requirements.yml` — fixed pre-existing broken `version: master` pin on `ansible-django` (the default branch was renamed to `main`). TODO note added: pin to a sha once onaio/ansible-django#51 lands on `main`.

`tally_ho_django_pip_packages: [uwsgi, django-debug-toolbar]` is intentionally **kept**. The django role's mode-agnostic extras-pip step still installs these into the uv-created venv (the `ansible-django` molecule scenario explicitly verifies this cohabitation).

## Merge order / blockers

1. Land onaio/ansible-django#51 on `main`
2. Update this PR's `requirements.yml` to pin to that sha (replacing `version: main`)
3. Land this PR
4. Bump the `ansible/roles/tally-ho` submodule pointer in onaio/infrastructure
5. Redeploy stage (note: stage's `tally_ho_django_git_version` is `"django-upgrade"` — that ref must contain pyproject.toml + uv.lock from onaio/tally-ho#561 before the deploy will work)

## Test plan

- [ ] `ansible-lint` shows no new failures vs. master baseline (verified locally — the 2 pre-existing failures + 2 warnings are unchanged)
- [ ] After upstream PR lands and sha pin is applied, run `ansible-playbook -i inventories/tally-ho/stage tally_ho.yml` from infrastructure
- [ ] Confirm on stage host: `/usr/local/bin/uv` exists, `~tallyho/.virtualenvs/.../bin/uwsgi` exists, systemd services come up